### PR TITLE
Add configuration values for probe

### DIFF
--- a/charts/consul-autoencrypt-k8s/Chart.yaml
+++ b/charts/consul-autoencrypt-k8s/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.3.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/consul-autoencrypt-k8s/templates/deployment.yaml
+++ b/charts/consul-autoencrypt-k8s/templates/deployment.yaml
@@ -86,7 +86,9 @@ spec:
               command:
               - cat
               - /output/out.yaml
-            initialDelaySeconds: 30
+            periodSeconds: {{ .Values.probe.periodSeconds }}
+            initialDelaySeconds: {{ .Values.probe.initialDelaySeconds }}
+            timeoutSeconds: {{ .Values.probe.timeoutSeconds }}
           volumeMounts:
             - name: output
               mountPath: /output

--- a/charts/consul-autoencrypt-k8s/values.yaml
+++ b/charts/consul-autoencrypt-k8s/values.yaml
@@ -54,6 +54,11 @@ tolerations: []
 
 affinity: {}
 
+probe:
+  initialDelaySeconds: 30
+  periodSeconds: 30
+  timeoutSeconds: 5
+
 consul:
   consulK8SImage: hashicorp/consul-k8s:0.18.1
   tls:


### PR DESCRIPTION
- K8S 1.20 actually respects the default timeout of 1s, which usually is
too little time for probes
